### PR TITLE
Add image slideshow webpage for robot secondary screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8" />
+  <title>副屏幕幻灯片</title>
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+      padding: 0;
+      background: #000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    img {
+      max-width: 100%;
+      max-height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <img id="slideshow" src="" alt="幻灯片" />
+  <script src="slideshow.js"></script>
+</body>
+</html>

--- a/readme
+++ b/readme
@@ -1,1 +1,5 @@
 副屏幕网页
+
+将要轮播的图片放到 images 目录。
+运行 `node server.js` 后在浏览器中打开 `http://localhost:3000` 即可。
+图片会每 5 秒切换一张。

--- a/server.js
+++ b/server.js
@@ -1,0 +1,61 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 3000;
+const imagesDir = path.join(__dirname, 'images');
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.bmp': 'image/bmp',
+  '.svg': 'image/svg+xml'
+};
+
+function sendFile(res, filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = mimeTypes[ext] || 'application/octet-stream';
+  const stream = fs.createReadStream(filePath);
+  stream.once('open', () => {
+    res.writeHead(200, { 'Content-Type': contentType });
+    stream.pipe(res);
+  });
+  stream.once('error', () => {
+    res.writeHead(404);
+    res.end('Not found');
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/' || req.url === '/index.html') {
+    sendFile(res, path.join(__dirname, 'index.html'));
+  } else if (req.url === '/slideshow.js') {
+    sendFile(res, path.join(__dirname, 'slideshow.js'));
+  } else if (req.url === '/api/images') {
+    fs.readdir(imagesDir, (err, files) => {
+      if (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Unable to read images directory' }));
+        return;
+      }
+      const images = files.filter(f => /\.(png|jpe?g|gif|bmp|svg)$/i.test(f));
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(images));
+    });
+  } else if (req.url.startsWith('/images/')) {
+    const filePath = path.join(imagesDir, req.url.replace('/images/', ''));
+    sendFile(res, filePath);
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});

--- a/slideshow.js
+++ b/slideshow.js
@@ -1,0 +1,18 @@
+const img = document.getElementById('slideshow');
+let images = [];
+let index = 0;
+
+function showNext() {
+  if (images.length === 0) return;
+  img.src = `/images/${images[index]}`;
+  index = (index + 1) % images.length;
+}
+
+fetch('/api/images')
+  .then(res => res.json())
+  .then(list => {
+    images = list;
+    showNext();
+    setInterval(showNext, 5000);
+  })
+  .catch(err => console.error('加载图片列表失败:', err));


### PR DESCRIPTION
## Summary
- add simple HTTP server to serve index and images
- add front-end script to rotate images every five seconds
- document usage in readme
- serve static files with proper MIME types and streaming

## Testing
- `node server.js & SERVER_PID=$!; sleep 1; curl -s http://localhost:3000/api/images; curl -s -I http://localhost:3000/index.html; curl -s -I http://localhost:3000/images/test.jpg; kill $SERVER_PID`

------
https://chatgpt.com/codex/tasks/task_e_689911914c34832a9c612ce96be394d8