### PR TITLE
Add logo support and smoother portrait slideshow

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,18 +9,49 @@
       margin: 0;
       padding: 0;
       background: #000;
-      display: flex;
-      align-items: center;
-      justify-content: center;
     }
-    img {
+
+    #container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-start;
+      height: 100%;
+      width: 100%;
+    }
+
+    #logo-container {
+      background: #fff;
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      padding: 10px 0;
+    }
+
+    #logo {
+      max-height: 100px;
+    }
+
+    #slideshow {
+      flex: 1;
       max-width: 100%;
       max-height: 100%;
+      object-fit: contain;
+      transition: opacity 1s ease-in-out;
+    }
+
+    #slideshow.fade-out {
+      opacity: 0;
     }
   </style>
 </head>
 <body>
-  <img id="slideshow" src="" alt="幻灯片" />
+  <div id="container">
+    <div id="logo-container">
+      <img id="logo" src="/logos/logo.svg" alt="Logo" />
+    </div>
+    <img id="slideshow" src="" alt="幻灯片" />
+  </div>
   <script src="slideshow.js"></script>
 </body>
 </html>

--- a/logos/logo.svg
+++ b/logos/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#ffffff"/>
+  <text x="50" y="55" font-size="20" text-anchor="middle" fill="#000000">Logo</text>
+</svg>

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 const port = process.env.PORT || 3000;
 const imagesDir = path.join(__dirname, 'images');
+const logosDir = path.join(__dirname, 'logos');
 
 const mimeTypes = {
   '.html': 'text/html',
@@ -49,6 +50,9 @@ const server = http.createServer((req, res) => {
     });
   } else if (req.url.startsWith('/images/')) {
     const filePath = path.join(imagesDir, req.url.replace('/images/', ''));
+    sendFile(res, filePath);
+  } else if (req.url.startsWith('/logos/')) {
+    const filePath = path.join(logosDir, req.url.replace('/logos/', ''));
     sendFile(res, filePath);
   } else {
     res.writeHead(404);

--- a/slideshow.js
+++ b/slideshow.js
@@ -4,15 +4,22 @@ let index = 0;
 
 function showNext() {
   if (images.length === 0) return;
-  img.src = `/images/${images[index]}`;
-  index = (index + 1) % images.length;
+  img.classList.add('fade-out');
+  setTimeout(() => {
+    img.src = `/images/${images[index]}`;
+    index = (index + 1) % images.length;
+    img.classList.remove('fade-out');
+  }, 1000);
 }
 
 fetch('/api/images')
   .then(res => res.json())
   .then(list => {
     images = list;
-    showNext();
-    setInterval(showNext, 5000);
+    if (images.length > 0) {
+      img.src = `/images/${images[0]}`;
+      index = 1;
+      setInterval(showNext, 5000);
+    }
   })
   .catch(err => console.error('加载图片列表失败:', err));


### PR DESCRIPTION
## Summary
- display a logo from new `logos` folder above slideshow on white background
- smooth slideshow transitions and format layout for portrait screens
- serve logo assets via server

## Testing
- `node server.js & sleep 1; curl -I http://localhost:3000/logos/logo.svg; curl -I http://localhost:3000/; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_68996e02f1a8832a8d3e545b2d47001a