### PR TITLE
Add logo support and smoother portrait slideshow

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,9 +34,9 @@
 
     #slideshow {
       flex: 1;
-      max-width: 100%;
-      max-height: 100%;
-      object-fit: contain;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
       transition: opacity 1s ease-in-out;
     }
 
@@ -48,7 +48,7 @@
 <body>
   <div id="container">
     <div id="logo-container">
-      <img id="logo" src="/logos/logo.png" alt="Logo" />
+      <img id="logo" src="/logos/logo.svg" alt="Logo" />
     </div>
     <img id="slideshow" src="" alt="幻灯片" />
   </div>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
 <body>
   <div id="container">
     <div id="logo-container">
+      <!-- Display the PNG logo; ensure logos/logo.png exists -->
       <img id="logo" src="/logos/logo.png" alt="Logo" />
     </div>
     <img id="slideshow" src="" alt="幻灯片" />

--- a/index.html
+++ b/index.html
@@ -9,18 +9,49 @@
       margin: 0;
       padding: 0;
       background: #000;
-      display: flex;
-      align-items: center;
-      justify-content: center;
     }
-    img {
+
+    #container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-start;
+      height: 100%;
+      width: 100%;
+    }
+
+    #logo-container {
+      background: #fff;
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      padding: 10px 0;
+    }
+
+    #logo {
+      max-height: 100px;
+    }
+
+    #slideshow {
+      flex: 1;
       max-width: 100%;
       max-height: 100%;
+      object-fit: contain;
+      transition: opacity 1s ease-in-out;
+    }
+
+    #slideshow.fade-out {
+      opacity: 0;
     }
   </style>
 </head>
 <body>
-  <img id="slideshow" src="" alt="幻灯片" />
+  <div id="container">
+    <div id="logo-container">
+      <img id="logo" src="/logos/logo.png" alt="Logo" />
+    </div>
+    <img id="slideshow" src="" alt="幻灯片" />
+  </div>
   <script src="slideshow.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,6 @@
 <body>
   <div id="container">
     <div id="logo-container">
-      <!-- Display the PNG logo; ensure logos/logo.png exists -->
       <img id="logo" src="/logos/logo.png" alt="Logo" />
     </div>
     <img id="slideshow" src="" alt="幻灯片" />

--- a/logos/README.md
+++ b/logos/README.md
@@ -1,0 +1,1 @@
+请在此目录放置名为 logo.png 的 PNG 格式 logo 文件。

--- a/logos/README.md
+++ b/logos/README.md
@@ -1,1 +1,1 @@
-请在此目录放置名为 logo.png 的 PNG 格式 logo 文件。
+请在此目录放置名为 logo.svg 的 SVG 格式 logo 文件。

--- a/readme
+++ b/readme
@@ -1,5 +1,5 @@
 副屏幕网页
 
-将要轮播的图片放到 images 目录，logo.png 文件放在 logos 目录（仓库中未包含示例文件）。
+将要轮播的图片放到 images 目录，logo.svg 文件放在 logos 目录（仓库中未包含示例文件）。
 运行 `node server.js` 后在浏览器中打开 `http://localhost:3000` 即可。
 图片会每 5 秒切换一张。

--- a/readme
+++ b/readme
@@ -1,5 +1,5 @@
 副屏幕网页
 
-将要轮播的图片放到 images 目录。
+将要轮播的图片放到 images 目录，logo.png 文件放在 logos 目录（仓库中未包含示例文件）。
 运行 `node server.js` 后在浏览器中打开 `http://localhost:3000` 即可。
 图片会每 5 秒切换一张。

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 const port = process.env.PORT || 3000;
 const imagesDir = path.join(__dirname, 'images');
+const logosDir = path.join(__dirname, 'logos');
 
 const mimeTypes = {
   '.html': 'text/html',
@@ -17,25 +18,34 @@ const mimeTypes = {
   '.svg': 'image/svg+xml'
 };
 
-function sendFile(res, filePath) {
+function sendFile(req, res, filePath) {
   const ext = path.extname(filePath).toLowerCase();
   const contentType = mimeTypes[ext] || 'application/octet-stream';
-  const stream = fs.createReadStream(filePath);
-  stream.once('open', () => {
-    res.writeHead(200, { 'Content-Type': contentType });
-    stream.pipe(res);
-  });
-  stream.once('error', () => {
-    res.writeHead(404);
-    res.end('Not found');
+  fs.stat(filePath, (err, stats) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': contentType, 'Content-Length': stats.size });
+    if (req.method === 'HEAD') {
+      res.end();
+    } else {
+      const stream = fs.createReadStream(filePath);
+      stream.once('error', () => {
+        res.writeHead(404);
+        res.end('Not found');
+      });
+      stream.pipe(res);
+    }
   });
 }
 
 const server = http.createServer((req, res) => {
   if (req.url === '/' || req.url === '/index.html') {
-    sendFile(res, path.join(__dirname, 'index.html'));
+    sendFile(req, res, path.join(__dirname, 'index.html'));
   } else if (req.url === '/slideshow.js') {
-    sendFile(res, path.join(__dirname, 'slideshow.js'));
+    sendFile(req, res, path.join(__dirname, 'slideshow.js'));
   } else if (req.url === '/api/images') {
     fs.readdir(imagesDir, (err, files) => {
       if (err) {
@@ -49,7 +59,10 @@ const server = http.createServer((req, res) => {
     });
   } else if (req.url.startsWith('/images/')) {
     const filePath = path.join(imagesDir, req.url.replace('/images/', ''));
-    sendFile(res, filePath);
+    sendFile(req, res, filePath);
+  } else if (req.url.startsWith('/logos/')) {
+    const filePath = path.join(logosDir, req.url.replace('/logos/', ''));
+    sendFile(req, res, filePath);
   } else {
     res.writeHead(404);
     res.end('Not found');

--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ const mimeTypes = {
   '.svg': 'image/svg+xml'
 };
 
-function sendFile(req, res, filePath) {
+function sendFile(res, filePath, method) {
   const ext = path.extname(filePath).toLowerCase();
   const contentType = mimeTypes[ext] || 'application/octet-stream';
   fs.stat(filePath, (err, stats) => {
@@ -28,7 +28,7 @@ function sendFile(req, res, filePath) {
       return;
     }
     res.writeHead(200, { 'Content-Type': contentType, 'Content-Length': stats.size });
-    if (req.method === 'HEAD') {
+    if (method === 'HEAD') {
       res.end();
     } else {
       const stream = fs.createReadStream(filePath);
@@ -43,9 +43,9 @@ function sendFile(req, res, filePath) {
 
 const server = http.createServer((req, res) => {
   if (req.url === '/' || req.url === '/index.html') {
-    sendFile(req, res, path.join(__dirname, 'index.html'));
+    sendFile(res, path.join(__dirname, 'index.html'), req.method);
   } else if (req.url === '/slideshow.js') {
-    sendFile(req, res, path.join(__dirname, 'slideshow.js'));
+    sendFile(res, path.join(__dirname, 'slideshow.js'), req.method);
   } else if (req.url === '/api/images') {
     fs.readdir(imagesDir, (err, files) => {
       if (err) {
@@ -59,10 +59,10 @@ const server = http.createServer((req, res) => {
     });
   } else if (req.url.startsWith('/images/')) {
     const filePath = path.join(imagesDir, req.url.replace('/images/', ''));
-    sendFile(req, res, filePath);
+    sendFile(res, filePath, req.method);
   } else if (req.url.startsWith('/logos/')) {
     const filePath = path.join(logosDir, req.url.replace('/logos/', ''));
-    sendFile(req, res, filePath);
+    sendFile(res, filePath, req.method);
   } else {
     res.writeHead(404);
     res.end('Not found');

--- a/slideshow.js
+++ b/slideshow.js
@@ -4,15 +4,22 @@ let index = 0;
 
 function showNext() {
   if (images.length === 0) return;
-  img.src = `/images/${images[index]}`;
-  index = (index + 1) % images.length;
+  img.classList.add('fade-out');
+  setTimeout(() => {
+    img.src = `/images/${images[index]}`;
+    index = (index + 1) % images.length;
+    img.classList.remove('fade-out');
+  }, 1000);
 }
 
 fetch('/api/images')
   .then(res => res.json())
   .then(list => {
     images = list;
-    showNext();
-    setInterval(showNext, 5000);
+    if (images.length > 0) {
+      img.src = `/images/${images[0]}`;
+      index = 1;
+      setInterval(showNext, 5000);
+    }
   })
   .catch(err => console.error('加载图片列表失败:', err));


### PR DESCRIPTION
## Summary
- display a logo from new `logos` folder above slideshow on white background
- smooth slideshow transitions and format layout for portrait screens
- serve logo assets via server with PNG format
- support HEAD requests for static files to avoid sending binary data
- remove sample binary logo and document logo placement

## Testing
- `node server.js & sleep 1; curl -I http://localhost:3000/logos/logo.png; curl -I http://localhost:3000/; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_68996e02f1a8832a8d3e545b2d47001a